### PR TITLE
Document list_actions and execute_action write tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 <!-- Canonical: https://mcp.windsor.ai/docs -->
 <!-- Last updated: May 2026 -->
 
-Windsor MCP (Model Context Protocol) is a hosted MCP server that lets your AI assistant query, explore and analyze live business data from 325+ sources — Meta Ads, Google Ads, TikTok Ads, GA4, HubSpot, Salesforce, Shopify, Stripe, BigQuery, Snowflake and many more — with no SQL, no API keys, and no custom integrations.
+Windsor MCP (Model Context Protocol) is a hosted MCP server that lets your AI assistant query, explore and analyze live business data from 325+ sources — Meta Ads, Google Ads, TikTok Ads, GA4, HubSpot, Salesforce, Shopify, Stripe, BigQuery, Snowflake and many more — with no SQL, no API keys, and no custom integrations. On connectors that support it, agents can also execute **write actions** — for example pausing or enabling ad campaigns and adjusting budgets on Meta Ads, Google Ads and TikTok Ads.
 
-It works with Claude, ChatGPT, Microsoft Copilot, Cursor, Windsurf, Cline, GitHub Copilot, Gemini, Manus, and any MCP-compatible client.
+It works with Claude, ChatGPT, Microsoft Copilot, Perplexity, Cursor, Windsurf, Cline, GitHub Copilot, Gemini, Manus, and any MCP-compatible client.
 
 > **TL;DR**
 > - Native connector in **Claude** (in the Claude directory) and **ChatGPT** (as a ChatGPT app).
+> - **Read and write**: query data from 325+ sources, and execute write actions (e.g. pause/enable ad campaigns) on connectors that expose them.
 > - **OAuth 2.0** — sign in once at Windsor.ai, no API keys to manage.
 > - **Free forever plan available** at Windsor.ai; some LLM providers (e.g. Claude) require a paid plan to use connectors.
 > - Live, machine-readable docs for AI agents at [`/llms.txt`](https://mcp.windsor.ai/llms.txt), [`/llms-full.txt`](https://mcp.windsor.ai/llms-full.txt), and [`/datasources`](https://mcp.windsor.ai/datasources).
@@ -28,6 +29,14 @@ Ask questions like:
 
 All in real-time, directly inside your LLM chat interface.
 
+### Write actions, not just reads
+Ask your assistant to act on the insights it surfaces — for connectors that expose write actions (e.g. Meta Ads, Google Ads, TikTok Ads):
+- "Pause my underperforming Meta Ads campaigns from last week."
+- "Re-enable the Google Ads campaign 'Summer Sale 2026'."
+- "Cut the daily budget on this TikTok Ads campaign by 20%."
+
+Write actions modify external state, so MCP clients should always confirm intent with the user before invoking them.
+
 ### Out-of-the-box integration with 325+ sources
 Sync data from Meta Ads, Google Ads, TikTok Ads, LinkedIn Ads, GA4, HubSpot, Salesforce, Shopify, Stripe, BigQuery, Snowflake, QuickBooks, Xero, and 300+ more via native Windsor.ai connectors. Full live list at [mcp.windsor.ai/datasources](https://mcp.windsor.ai/datasources).
 
@@ -35,7 +44,7 @@ Sync data from Meta Ads, Google Ads, TikTok Ads, LinkedIn Ads, GA4, HubSpot, Sal
 Windsor MCP is available as a native connector in Claude and ChatGPT — just enable it and sign in. No proxies, no scripts, no custom integrations.
 
 ### Open standard compatibility
-Built on the open MCP spec, it's compatible with Claude, ChatGPT, Microsoft Copilot, Cursor, Windsurf, Cline, GitHub Copilot, Gemini, Manus, n8n, and any MCP-compatible client.
+Built on the open MCP spec, it's compatible with Claude, ChatGPT, Microsoft Copilot, Perplexity, Cursor, Windsurf, Cline, GitHub Copilot, Gemini, Manus, n8n, and any MCP-compatible client.
 
 ### Real-time analytics without SQL
 Get instant breakdowns, summaries and performance insights from your integrated data — no dashboards to build, no queries to write.
@@ -66,7 +75,7 @@ The server endpoint is `https://mcp.windsor.ai/`. Authentication is OAuth 2.0 �
 
 ### Available tools
 
-All tools are read-only — they fetch data, never modify it.
+**Read tools** — fetch data, never modify it.
 
 - **`get_current_user`** — Return the authenticated user's profile. Use this as a sanity check that auth is working.
 - **`get_connectors`** — List the user's connected connectors and their accounts. Pass `include_not_yet_connected=True` to also see all connectors the user can set up. Always call this first to discover available data sources.
@@ -77,6 +86,11 @@ All tools are read-only — they fetch data, never modify it.
 
 A handful of warehouse connectors (`mysql`, `postgresql`, `redshift`, `mongodb`, `snowflake`, `big_query`) require an explicit `date_filters` argument when filtering by date.
 
+**Write tools** — available on connectors that expose actions (e.g. ad platforms).
+
+- **`list_actions`** — Discover write actions available for a connector. Each action includes a JSON schema describing the params it accepts. Read-only connectors return an empty list. Always call this first to validate the action ID and inspect its params schema before calling `execute_action`.
+- **`execute_action`** — Run a write action (e.g. pause/enable a campaign, change a budget) against a connected account. Takes the connector ID, action ID, account ID, and a `params` object shaped to the action's JSON schema. Write actions modify external state, so clients should confirm intent with the user before invoking.
+
 For full parameter signatures, see [`/llms-full.txt`](https://mcp.windsor.ai/llms-full.txt).
 
 ---
@@ -85,14 +99,15 @@ For full parameter signatures, see [`/llms-full.txt`](https://mcp.windsor.ai/llm
 
 | Client | How to install | Auth | Setup time |
 |---|---|---|---|
-| **Claude** (Desktop, Web, Code) | [One-click install](https://claude.ai/directory/360c0c31-4bb6-42ca-8e50-5da0a100a68e) — listed in the Claude directory | OAuth 2.0 | ~30 seconds |
-| **ChatGPT** | [One-click install](https://chatgpt.com/apps/windsor-ai/asdk_app_694a52cfaa3c819192bea84eaa254968) — listed as a ChatGPT app | OAuth 2.0 | ~30 seconds |
+| **Claude** (Desktop, Web, Code) | [One-click install](https://claude.ai/directory/360c0c31-4bb6-42ca-8e50-5da0a100a68e) — listed in the Claude directory · [setup guide](https://windsor.ai/documentation/windsor-mcp/how-to-integrate-data-into-claude/) | OAuth 2.0 | ~30 seconds |
+| **ChatGPT** | [One-click install](https://chatgpt.com/apps/windsor-ai/asdk_app_694a52cfaa3c819192bea84eaa254968) — listed as a ChatGPT app · [setup guide](https://windsor.ai/documentation/windsor-mcp/how-to-integrate-data-into-chatgpt/) | OAuth 2.0 | ~30 seconds |
 | **Microsoft Copilot** | [Windsor.ai Power Platform connector](https://learn.microsoft.com/en-us/connectors/windsorai/) — see [integration guide](https://windsor.ai/documentation/windsor-mcp/how-to-integrate-data-into-copilot-agent/) | API key | ~5 minutes |
+| **Perplexity** | See [setup guide](https://windsor.ai/documentation/windsor-mcp/how-to-integrate-data-into-perplexity/) | OAuth 2.0 | ~1 minute |
 | **Claude Code** | `claude plugin install windsor-ai` — [source](https://github.com/windsor-ai/claude-windsor-ai-plugin), with slash commands and an analyst agent | OAuth 2.0 | ~1 minute |
-| **Cursor** | [windsor-ai/windsor-ai-cursor-plugin](https://github.com/windsor-ai/windsor-ai-cursor-plugin), or paste the config below | OAuth 2.0 | ~1 minute |
+| **Cursor** | [windsor-ai/windsor-ai-cursor-plugin](https://github.com/windsor-ai/windsor-ai-cursor-plugin), or paste the config below · [setup guide](https://windsor.ai/documentation/windsor-mcp/how-to-integrate-data-into-cursor/) | OAuth 2.0 | ~1 minute |
 | **Manus** | Add `https://mcp.windsor.ai/` as an MCP server — see [integration guide](https://windsor.ai/documentation/windsor-mcp/how-to-integrate-data-into-manus-ai/) | OAuth 2.0 | ~1 minute |
-| **Windsurf, Cline, GitHub Copilot, n8n** | Standard MCP server config (`url: https://mcp.windsor.ai/`) | OAuth 2.0 | ~1 minute |
-| **Gemini CLI** | Edit `~/.gemini/settings.json` (config below) | OAuth 2.0 | ~2 minutes |
+| **Windsurf, Cline, GitHub Copilot, n8n** | Standard MCP server config (`url: https://mcp.windsor.ai/`) — see [generic setup guide](https://windsor.ai/documentation/windsor-mcp/how-to-connect-windsor-mcp-to-any-ai-client/) | OAuth 2.0 | ~1 minute |
+| **Gemini CLI** | Edit `~/.gemini/settings.json` (config below) — see [setup guide](https://windsor.ai/documentation/windsor-mcp/how-to-integrate-data-into-gemini/) | OAuth 2.0 | ~2 minutes |
 
 Any MCP-compatible client works. If your client only supports API keys, pass your Windsor.ai key as `Authorization: Bearer <key>`.
 
@@ -122,7 +137,8 @@ Don't see what you need? Call `get_connectors(include_not_yet_connected=True)` f
 ## 🚀 Getting started
 
 ### View our official documentation
-[https://windsor.ai/introducing-windsor-mcp/](https://windsor.ai/introducing-windsor-mcp/)
+- Introduction: [windsor.ai/introducing-windsor-mcp/](https://windsor.ai/introducing-windsor-mcp/)
+- Setup guides hub: [windsor.ai/documentation/windsor-mcp/](https://windsor.ai/documentation/windsor-mcp/) — step-by-step guides per AI client (Claude, ChatGPT, Microsoft Copilot, Perplexity, Cursor, Gemini, Manus, and the generic "any MCP client" guide).
 
 You'll need a Windsor.ai account — sign up at [onboard.windsor.ai](https://onboard.windsor.ai).
 
@@ -258,7 +274,7 @@ Yes — Windsor.ai has a free forever plan, and the MCP server is included at no
 Any AI agent compatible with MCP — including Claude (Desktop, Web, Code), ChatGPT, Microsoft Copilot (via the Power Platform connector), Cursor, Windsurf, Cline, GitHub Copilot, Gemini, Manus, n8n, mcp-proxy, and custom MCP clients. See the [Supported AI clients](#-supported-ai-clients) table above.
 
 ### What can I ask Windsor MCP?
-Marketing performance, sales pipelines, CRM data, e-commerce orders, payment activity, finance metrics, ad spend summaries, ROAS trends, campaign anomalies, multi-channel attribution, warehouse queries, and more. If it's in your Windsor.ai data, you can ask it.
+Marketing performance, sales pipelines, CRM data, e-commerce orders, payment activity, finance metrics, ad spend summaries, ROAS trends, campaign anomalies, multi-channel attribution, warehouse queries, and more. If it's in your Windsor.ai data, you can ask it. On connectors that expose write actions (e.g. Meta Ads, Google Ads, TikTok Ads), you can also ask the assistant to act on what it finds — for example, "pause the campaigns that burned budget last week" or "cut this campaign's daily budget by 20%".
 
 ### What data sources does Windsor MCP support?
 325+ connectors across advertising, analytics, CRM, e-commerce, payments, warehouses and more. The live, complete list is at [mcp.windsor.ai/datasources](https://mcp.windsor.ai/datasources). See the [Supported data sources](#-supported-data-sources) section for highlights by category.
@@ -270,7 +286,7 @@ No. Just ask your questions in plain English and get structured responses in rea
 OAuth 2.0 is the default — your client redirects you to Windsor.ai for a one-time login. The server implements MCP OAuth with Dynamic Client Registration; clients that support MCP OAuth (Claude, ChatGPT, Cursor, Manus) discover the endpoints automatically. For setups that only support API keys, pass your Windsor.ai key as a Bearer token via the `Authorization` header.
 
 ### Is my data secure with Windsor MCP?
-Yes. All Windsor MCP tools are read-only — they fetch data, they cannot write or modify anything in your sources. Authentication is OAuth 2.0; the MCP server does not store your Windsor.ai password and does not retain query results. Data flows over TLS. Windsor.ai is SOC 2 compliant. For details, see [windsor.ai/security](https://windsor.ai/security).
+Yes. Windsor MCP exposes both read tools (which only fetch data) and a small number of write tools (`list_actions`, `execute_action`) on connectors that opt into actions — for example, pausing or enabling an ad campaign. Write actions are explicitly flagged as destructive to MCP clients, which prompt you to confirm intent before invoking them; nothing is changed in your sources without your approval. Authentication is OAuth 2.0; the MCP server does not store your Windsor.ai password and does not retain query results. Data flows over TLS. Windsor.ai is SOC 2 compliant. For details, see [windsor.ai/security](https://windsor.ai/security).
 
 ### How is Windsor MCP different from other data integration tools?
 Windsor MCP is a native MCP server, not a plugin or wrapper — it works in any MCP-compatible client without proxies. Windsor.ai includes warehouse and database destinations (BigQuery, Snowflake, Redshift, S3, MySQL, Postgres) on its lower-priced tiers, and the MCP server is included on all paid plans at no extra cost. See [windsor.ai/pricing](https://windsor.ai/pricing) for a feature-by-feature comparison.


### PR DESCRIPTION
## Summary
- Bring the public README in sync with the write-feature work in the source repo: surface `list_actions` and `execute_action` (pause/enable ad campaigns, adjust budgets) in the opening tagline, TL;DR, a new "Write actions, not just reads" Features subsection, the Available tools list (now split into Read / Write), and the "What can I ask" / security FAQs.
- Replace the stale "all tools are read-only" claim with an accurate description of the `destructiveHint` flag and the confirm-before-invoke behaviour MCP clients enforce.
- Mirror the docs published at `mcp.windsor.ai/llms.txt`, `mcp.windsor.ai/llms-full.txt`, and the landing page (see source-repo commit documenting the write feature).

## Test plan
- [ ] Render `README.md` on GitHub and confirm the new "Write actions, not just reads" Features subsection and the split Read/Write tools list render correctly.
- [ ] Sanity-check the security FAQ no longer claims tools are read-only and accurately describes the confirm-before-invoke flow.
- [ ] Spot-check tool names (`list_actions`, `execute_action`) match the source repo's `windsor_mcp/server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)